### PR TITLE
feat(survey): Integrar paleta de colores AURA en la encuesta para entrenadores

### DIFF
--- a/public/styles/tailwind.css
+++ b/public/styles/tailwind.css
@@ -1519,9 +1519,34 @@ body {
   border-color: rgb(250 198 87 / 0.2);
 }
 
-.border-emerald-600 {
+.border-aura-accent {
   --tw-border-opacity: 1;
-  border-color: rgb(5 150 105 / var(--tw-border-opacity));
+  border-color: rgb(255 195 63 / var(--tw-border-opacity));
+}
+
+.border-aura-green {
+  --tw-border-opacity: 1;
+  border-color: rgb(151 221 171 / var(--tw-border-opacity));
+}
+
+.border-aura-orange {
+  --tw-border-opacity: 1;
+  border-color: rgb(237 146 99 / var(--tw-border-opacity));
+}
+
+.border-aura-primary {
+  --tw-border-opacity: 1;
+  border-color: rgb(170 73 204 / var(--tw-border-opacity));
+}
+
+.border-aura-rose {
+  --tw-border-opacity: 1;
+  border-color: rgb(203 98 154 / var(--tw-border-opacity));
+}
+
+.border-aura-secondary {
+  --tw-border-opacity: 1;
+  border-color: rgb(124 224 200 / var(--tw-border-opacity));
 }
 
 .border-gray-100 {
@@ -1544,11 +1569,6 @@ body {
   border-color: rgb(79 70 229 / var(--tw-border-opacity));
 }
 
-.border-purple-600 {
-  --tw-border-opacity: 1;
-  border-color: rgb(147 51 234 / var(--tw-border-opacity));
-}
-
 .border-red-300 {
   --tw-border-opacity: 1;
   border-color: rgb(252 165 165 / var(--tw-border-opacity));
@@ -1561,21 +1581,6 @@ body {
 
 .border-red-500\/50 {
   border-color: rgb(239 68 68 / 0.5);
-}
-
-.border-rose-600 {
-  --tw-border-opacity: 1;
-  border-color: rgb(225 29 72 / var(--tw-border-opacity));
-}
-
-.border-sky-600 {
-  --tw-border-opacity: 1;
-  border-color: rgb(2 132 199 / var(--tw-border-opacity));
-}
-
-.border-teal-600 {
-  --tw-border-opacity: 1;
-  border-color: rgb(13 148 136 / var(--tw-border-opacity));
 }
 
 .border-white\/10 {
@@ -1641,14 +1646,58 @@ body {
   background-color: rgb(255 195 63 / var(--tw-bg-opacity));
 }
 
-.bg-emerald-100 {
+.bg-aura-accent {
   --tw-bg-opacity: 1;
-  background-color: rgb(209 250 229 / var(--tw-bg-opacity));
+  background-color: rgb(255 195 63 / var(--tw-bg-opacity));
 }
 
-.bg-emerald-600 {
+.bg-aura-accent\/10 {
+  background-color: rgb(255 195 63 / 0.1);
+}
+
+.bg-aura-green {
   --tw-bg-opacity: 1;
-  background-color: rgb(5 150 105 / var(--tw-bg-opacity));
+  background-color: rgb(151 221 171 / var(--tw-bg-opacity));
+}
+
+.bg-aura-green\/10 {
+  background-color: rgb(151 221 171 / 0.1);
+}
+
+.bg-aura-orange {
+  --tw-bg-opacity: 1;
+  background-color: rgb(237 146 99 / var(--tw-bg-opacity));
+}
+
+.bg-aura-orange\/10 {
+  background-color: rgb(237 146 99 / 0.1);
+}
+
+.bg-aura-primary {
+  --tw-bg-opacity: 1;
+  background-color: rgb(170 73 204 / var(--tw-bg-opacity));
+}
+
+.bg-aura-primary\/10 {
+  background-color: rgb(170 73 204 / 0.1);
+}
+
+.bg-aura-rose {
+  --tw-bg-opacity: 1;
+  background-color: rgb(203 98 154 / var(--tw-bg-opacity));
+}
+
+.bg-aura-rose\/10 {
+  background-color: rgb(203 98 154 / 0.1);
+}
+
+.bg-aura-secondary {
+  --tw-bg-opacity: 1;
+  background-color: rgb(124 224 200 / var(--tw-bg-opacity));
+}
+
+.bg-aura-secondary\/10 {
+  background-color: rgb(124 224 200 / 0.1);
 }
 
 .bg-gray-100 {
@@ -1681,16 +1730,6 @@ body {
   background-color: rgb(79 70 229 / var(--tw-bg-opacity));
 }
 
-.bg-purple-100 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(243 232 255 / var(--tw-bg-opacity));
-}
-
-.bg-purple-600 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(147 51 234 / var(--tw-bg-opacity));
-}
-
 .bg-red-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(254 226 226 / var(--tw-bg-opacity));
@@ -1698,36 +1737,6 @@ body {
 
 .bg-red-500\/20 {
   background-color: rgb(239 68 68 / 0.2);
-}
-
-.bg-rose-100 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(255 228 230 / var(--tw-bg-opacity));
-}
-
-.bg-rose-600 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(225 29 72 / var(--tw-bg-opacity));
-}
-
-.bg-sky-100 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(224 242 254 / var(--tw-bg-opacity));
-}
-
-.bg-sky-600 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(2 132 199 / var(--tw-bg-opacity));
-}
-
-.bg-teal-100 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(204 251 241 / var(--tw-bg-opacity));
-}
-
-.bg-teal-600 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(13 148 136 / var(--tw-bg-opacity));
 }
 
 .bg-white {
@@ -2084,14 +2093,44 @@ body {
   color: rgb(255 195 63 / var(--tw-text-opacity));
 }
 
-.text-emerald-600 {
+.text-aura-accent {
   --tw-text-opacity: 1;
-  color: rgb(5 150 105 / var(--tw-text-opacity));
+  color: rgb(255 195 63 / var(--tw-text-opacity));
 }
 
-.text-emerald-900 {
+.text-aura-green {
   --tw-text-opacity: 1;
-  color: rgb(6 78 59 / var(--tw-text-opacity));
+  color: rgb(151 221 171 / var(--tw-text-opacity));
+}
+
+.text-aura-orange {
+  --tw-text-opacity: 1;
+  color: rgb(237 146 99 / var(--tw-text-opacity));
+}
+
+.text-aura-primary {
+  --tw-text-opacity: 1;
+  color: rgb(170 73 204 / var(--tw-text-opacity));
+}
+
+.text-aura-rose {
+  --tw-text-opacity: 1;
+  color: rgb(203 98 154 / var(--tw-text-opacity));
+}
+
+.text-aura-secondary {
+  --tw-text-opacity: 1;
+  color: rgb(124 224 200 / var(--tw-text-opacity));
+}
+
+.text-aura-text-dark {
+  --tw-text-opacity: 1;
+  color: rgb(42 27 61 / var(--tw-text-opacity));
+}
+
+.text-aura-text-light {
+  --tw-text-opacity: 1;
+  color: rgb(253 253 247 / var(--tw-text-opacity));
 }
 
 .text-gray-300 {
@@ -2139,16 +2178,6 @@ body {
   color: rgb(49 46 129 / var(--tw-text-opacity));
 }
 
-.text-purple-600 {
-  --tw-text-opacity: 1;
-  color: rgb(147 51 234 / var(--tw-text-opacity));
-}
-
-.text-purple-900 {
-  --tw-text-opacity: 1;
-  color: rgb(88 28 135 / var(--tw-text-opacity));
-}
-
 .text-red-500 {
   --tw-text-opacity: 1;
   color: rgb(239 68 68 / var(--tw-text-opacity));
@@ -2162,36 +2191,6 @@ body {
 .text-red-700 {
   --tw-text-opacity: 1;
   color: rgb(185 28 28 / var(--tw-text-opacity));
-}
-
-.text-rose-600 {
-  --tw-text-opacity: 1;
-  color: rgb(225 29 72 / var(--tw-text-opacity));
-}
-
-.text-rose-900 {
-  --tw-text-opacity: 1;
-  color: rgb(136 19 55 / var(--tw-text-opacity));
-}
-
-.text-sky-600 {
-  --tw-text-opacity: 1;
-  color: rgb(2 132 199 / var(--tw-text-opacity));
-}
-
-.text-sky-900 {
-  --tw-text-opacity: 1;
-  color: rgb(12 74 110 / var(--tw-text-opacity));
-}
-
-.text-teal-600 {
-  --tw-text-opacity: 1;
-  color: rgb(13 148 136 / var(--tw-text-opacity));
-}
-
-.text-teal-900 {
-  --tw-text-opacity: 1;
-  color: rgb(19 78 74 / var(--tw-text-opacity));
 }
 
 .text-white {
@@ -2404,9 +2403,28 @@ body {
   background-color: rgb(255 195 63 / 0.9);
 }
 
-.hover\:bg-emerald-700:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(4 120 87 / var(--tw-bg-opacity));
+.hover\:bg-aura-accent\/90:hover {
+  background-color: rgb(255 195 63 / 0.9);
+}
+
+.hover\:bg-aura-green\/90:hover {
+  background-color: rgb(151 221 171 / 0.9);
+}
+
+.hover\:bg-aura-orange\/90:hover {
+  background-color: rgb(237 146 99 / 0.9);
+}
+
+.hover\:bg-aura-primary\/90:hover {
+  background-color: rgb(170 73 204 / 0.9);
+}
+
+.hover\:bg-aura-rose\/90:hover {
+  background-color: rgb(203 98 154 / 0.9);
+}
+
+.hover\:bg-aura-secondary\/90:hover {
+  background-color: rgb(124 224 200 / 0.9);
 }
 
 .hover\:bg-gray-300:hover {
@@ -2427,26 +2445,6 @@ body {
 .hover\:bg-indigo-700:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(67 56 202 / var(--tw-bg-opacity));
-}
-
-.hover\:bg-purple-700:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(126 34 206 / var(--tw-bg-opacity));
-}
-
-.hover\:bg-rose-700:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(190 18 60 / var(--tw-bg-opacity));
-}
-
-.hover\:bg-sky-700:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(3 105 161 / var(--tw-bg-opacity));
-}
-
-.hover\:bg-teal-700:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(15 118 110 / var(--tw-bg-opacity));
 }
 
 .hover\:bg-white\/10:hover {
@@ -2517,6 +2515,10 @@ body {
 .focus\:ring-\[\#7CE0C8\]:focus {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(124 224 200 / var(--tw-ring-opacity));
+}
+
+.focus\:ring-aura-primary\/50:focus {
+  --tw-ring-color: rgb(170 73 204 / 0.5);
 }
 
 .focus\:ring-indigo-500:focus {

--- a/src/components/survey/ProgressBar.tsx
+++ b/src/components/survey/ProgressBar.tsx
@@ -1,41 +1,41 @@
 import React from 'react';
 import type { Block } from '../../data/surveyDefinition';
 
-// --- Mapas de Clases CSS para Colores Dinámicos ---
+// --- Mapas de Clases CSS para Colores Dinámicos (Actualizados con prefijo aura-) ---
 const bgColorClasses: { [key: string]: string } = {
-    indigo: 'bg-indigo-100',
-    purple: 'bg-purple-100',
-    sky: 'bg-sky-100',
-    teal: 'bg-teal-100',
-    rose: 'bg-rose-100',
-    emerald: 'bg-emerald-100',
+    'aura-primary': 'bg-aura-primary/10',
+    'aura-secondary': 'bg-aura-secondary/10',
+    'aura-accent': 'bg-aura-accent/10',
+    'aura-rose': 'bg-aura-rose/10',
+    'aura-orange': 'bg-aura-orange/10',
+    'aura-green': 'bg-aura-green/10',
 };
 
-const bgDarkClasses: { [key: string]: string } = {
-    indigo: 'bg-indigo-600',
-    purple: 'bg-purple-600',
-    sky: 'bg-sky-600',
-    teal: 'bg-teal-600',
-    rose: 'bg-rose-600',
-    emerald: 'bg-emerald-600',
+const bgDarkColorClasses: { [key: string]: string } = {
+    'aura-primary': 'bg-aura-primary',
+    'aura-secondary': 'bg-aura-secondary',
+    'aura-accent': 'bg-aura-accent',
+    'aura-rose': 'bg-aura-rose',
+    'aura-orange': 'bg-aura-orange',
+    'aura-green': 'bg-aura-green',
 };
 
 const textColorClasses: { [key: string]: string } = {
-    indigo: 'text-indigo-600',
-    purple: 'text-purple-600',
-    sky: 'text-sky-600',
-    teal: 'text-teal-600',
-    rose: 'text-rose-600',
-    emerald: 'text-emerald-600',
+    'aura-primary': 'text-aura-primary',
+    'aura-secondary': 'text-aura-secondary',
+    'aura-accent': 'text-aura-accent',
+    'aura-rose': 'text-aura-rose',
+    'aura-orange': 'text-aura-orange',
+    'aura-green': 'text-aura-green',
 };
 
 const borderColorClasses: { [key: string]: string } = {
-    indigo: 'border-indigo-600',
-    purple: 'border-purple-600',
-    sky: 'border-sky-600',
-    teal: 'border-teal-600',
-    rose: 'border-rose-600',
-    emerald: 'border-emerald-600',
+    'aura-primary': 'border-aura-primary',
+    'aura-secondary': 'border-aura-secondary',
+    'aura-accent': 'border-aura-accent',
+    'aura-rose': 'border-aura-rose',
+    'aura-orange': 'border-aura-orange',
+    'aura-green': 'border-aura-green',
 };
 // --- Fin Mapas de Clases ---
 
@@ -43,15 +43,15 @@ interface ProgressBarProps {
     currentStep: number;
     totalSteps: number;
     blocks: readonly Block[];
-    currentBlockColor: string; // Color del bloque actual
-    colorMap: { [key: string]: string }; // Mapa de colores
+    currentBlockColor: string; // Color del bloque actual (nombre, ej: 'aura-primary')
+    colorMap: { [key: string]: string }; // Mapa de colores por blockId
 }
 
 const ProgressBar: React.FC<ProgressBarProps> = ({ 
     currentStep, 
     totalSteps, 
     blocks, 
-    currentBlockColor, 
+    currentBlockColor, // Recibe el nombre del color, ej: 'aura-primary'
     colorMap 
 }) => {
     return (
@@ -59,7 +59,7 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
             <div className="flex justify-between mb-2 px-1">
                 {blocks.map((block, index) => {
                     const stepNumber = index + 1;
-                    const blockColor = colorMap[block.blockId] || 'indigo';
+                    const blockColorName = colorMap[block.blockId] || 'aura-primary';
                     const isCompleted = stepNumber < currentStep;
                     const isCurrent = stepNumber === currentStep;
                     const isFuture = stepNumber > currentStep;
@@ -69,12 +69,12 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
                     let titleOpacity = 'opacity-50';
 
                     if (isCompleted) {
-                        circleClasses = `${bgDarkClasses[blockColor]} text-white ${borderColorClasses[blockColor]}`;
-                        textClasses = textColorClasses[blockColor];
+                        circleClasses = `${bgDarkColorClasses[blockColorName]} text-aura-text-light ${borderColorClasses[blockColorName]}`;
+                        textClasses = textColorClasses[blockColorName];
                         titleOpacity = '';
                     } else if (isCurrent) {
-                        circleClasses = `${bgColorClasses[blockColor]} ${textColorClasses[blockColor]} ${borderColorClasses[blockColor]}`;
-                        textClasses = textColorClasses[blockColor];
+                        circleClasses = `${bgColorClasses[blockColorName]} ${textColorClasses[blockColorName]} ${borderColorClasses[blockColorName]}`;
+                        textClasses = textColorClasses[blockColorName];
                         titleOpacity = '';
                     }
                     
@@ -85,7 +85,6 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
                             style={{ flexBasis: `${100 / totalSteps}%` }}
                         >
                             <div
-                                // Aplicar clases de círculo dinámicas
                                 className={`w-8 h-8 md:w-10 md:h-10 rounded-full flex items-center justify-center mb-1 border-2 ${circleClasses}`}
                             >
                                 {isCompleted ? (
@@ -101,8 +100,7 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
             </div>
             <div className="h-2 bg-gray-200 rounded-full">
                 <div
-                    // Usar el color del bloque actual para la barra de progreso
-                    className={`h-2 ${bgDarkClasses[currentBlockColor]} rounded-full transition-all duration-500 ease-out`}
+                    className={`h-2 ${bgDarkColorClasses[currentBlockColor]} rounded-full transition-all duration-500 ease-out`}
                     style={{ width: `${totalSteps > 1 ? ((currentStep - 1) / (totalSteps - 1)) * 100 : 0}%` }} 
                 />
             </div>

--- a/src/components/survey/SurveyForm.tsx
+++ b/src/components/survey/SurveyForm.tsx
@@ -11,70 +11,73 @@ import { submitSurvey } from '../../utils/api'; // Adjusted path
 
 // --- Interfaces for Type Safety (Removed) ---
 
-// --- Mapa de Colores por Bloque ---
+// --- Mapa de Colores por Bloque (Actualizado con colores AURA) ---
 const blockColorMap: { [key: string]: string } = {
-  perfilProfesional: 'indigo',
-  gestionClientesDolor: 'purple',
-  creacionEntregaPlanes: 'sky',
-  usoPlataformasDigitales: 'teal',
-  diferenciacionComunicacion: 'rose', 
-  interesAura: 'emerald',
+  perfilProfesional: 'aura-primary',     // Morado
+  gestionClientesDolor: 'aura-rose',      // Rosa/Morado
+  creacionEntregaPlanes: 'aura-secondary', // Turquesa
+  usoPlataformasDigitales: 'aura-green',    // Verde Claro
+  diferenciacionComunicacion: 'aura-orange',   // Naranja
+  interesAura: 'aura-accent',        // Amarillo
 };
 // --- Fin Mapa de Colores ---
 
-// --- Mapas de Clases CSS para Colores Dinámicos ---
+// --- Mapas de Clases CSS para Colores Dinámicos (Actualizados con prefijo aura-) ---
 const borderColorClasses: { [key: string]: string } = {
-  indigo: 'border-t-4 border-indigo-600',
-  purple: 'border-t-4 border-purple-600',
-  sky: 'border-t-4 border-sky-600',
-  teal: 'border-t-4 border-teal-600',
-  rose: 'border-t-4 border-rose-600',
-  emerald: 'border-t-4 border-emerald-600',
+  'aura-primary': 'border-t-4 border-aura-primary',
+  'aura-secondary': 'border-t-4 border-aura-secondary',
+  'aura-accent': 'border-t-4 border-aura-accent',
+  'aura-rose': 'border-t-4 border-aura-rose',
+  'aura-orange': 'border-t-4 border-aura-orange',
+  'aura-green': 'border-t-4 border-aura-green',
 };
 
 const bgColorClasses: { [key: string]: string } = {
-  indigo: 'bg-indigo-100',
-  purple: 'bg-purple-100',
-  sky: 'bg-sky-100',
-  teal: 'bg-teal-100',
-  rose: 'bg-rose-100',
-  emerald: 'bg-emerald-100',
+  'aura-primary': 'bg-aura-primary/10', // Usar opacidad para fondos claros
+  'aura-secondary': 'bg-aura-secondary/10',
+  'aura-accent': 'bg-aura-accent/10',
+  'aura-rose': 'bg-aura-rose/10',
+  'aura-orange': 'bg-aura-orange/10',
+  'aura-green': 'bg-aura-green/10',
 };
 
 const textColorClasses: { [key: string]: string } = {
-  indigo: 'text-indigo-600',
-  purple: 'text-purple-600',
-  sky: 'text-sky-600',
-  teal: 'text-teal-600',
-  rose: 'text-rose-600',
-  emerald: 'text-emerald-600',
+  'aura-primary': 'text-aura-primary',
+  'aura-secondary': 'text-aura-secondary',
+  'aura-accent': 'text-aura-accent',
+  'aura-rose': 'text-aura-rose',
+  'aura-orange': 'text-aura-orange',
+  'aura-green': 'text-aura-green',
 };
 
-const bgButtonClasses: { [key: string]: string } = {
-  indigo: 'bg-indigo-600',
-  purple: 'bg-purple-600',
-  sky: 'bg-sky-600',
-  teal: 'bg-teal-600',
-  rose: 'bg-rose-600',
-  emerald: 'bg-emerald-600',
+// Clases para fondos oscuros (botones, barra de progreso)
+const bgDarkColorClasses: { [key: string]: string } = {
+  'aura-primary': 'bg-aura-primary',
+  'aura-secondary': 'bg-aura-secondary',
+  'aura-accent': 'bg-aura-accent',
+  'aura-rose': 'bg-aura-rose',
+  'aura-orange': 'bg-aura-orange',
+  'aura-green': 'bg-aura-green',
 };
 
-const hoverBgClasses: { [key: string]: string } = {
-  indigo: 'hover:bg-indigo-700',
-  purple: 'hover:bg-purple-700',
-  sky: 'hover:bg-sky-700',
-  teal: 'hover:bg-teal-700',
-  rose: 'hover:bg-rose-700',
-  emerald: 'hover:bg-emerald-700',
+// Clases para hover de fondos oscuros
+const hoverBgDarkColorClasses: { [key: string]: string } = {
+  'aura-primary': 'hover:bg-aura-primary/90',
+  'aura-secondary': 'hover:bg-aura-secondary/90',
+  'aura-accent': 'hover:bg-aura-accent/90',
+  'aura-rose': 'hover:bg-aura-rose/90',
+  'aura-orange': 'hover:bg-aura-orange/90',
+  'aura-green': 'hover:bg-aura-green/90',
 };
 
+// Clases para texto oscuro (títulos, etc.)
 const textDarkClasses: { [key: string]: string } = {
-  indigo: 'text-indigo-900',
-  purple: 'text-purple-900',
-  sky: 'text-sky-900',
-  teal: 'text-teal-900',
-  rose: 'text-rose-900',
-  emerald: 'text-emerald-900',
+  'aura-primary': 'text-aura-primary', // Usar el color principal para títulos oscuros
+  'aura-secondary': 'text-aura-secondary',
+  'aura-accent': 'text-aura-text-dark', // Texto oscuro normal para acento amarillo
+  'aura-rose': 'text-aura-rose',
+  'aura-orange': 'text-aura-orange',
+  'aura-green': 'text-aura-green',
 };
 // --- Fin Mapas de Clases ---
 
@@ -284,7 +287,7 @@ const SurveyForm: React.FC<SurveyFormProps> = ({ survey }) => {
     ];
 
     // Determinar color del bloque actual para ProgressBar
-    const currentBlockColorName = blockColorMap[survey.blocks[currentStep - 1]?.blockId] || 'indigo';
+    const currentBlockColorName = blockColorMap[survey.blocks[currentStep - 1]?.blockId] || 'aura-primary';
 
     // Orden de prioridad: Enviado > Enviando > Contexto > Intermedio Inicial > Formulario
     if (isSubmitted) {
@@ -296,7 +299,7 @@ const SurveyForm: React.FC<SurveyFormProps> = ({ survey }) => {
         console.log("Render: Enviando encuesta...");
         return (
             <div className="max-w-2xl mx-auto p-8 bg-white rounded-xl shadow-lg text-center transform transition-all duration-500 animate-pulse">
-                <svg className="w-16 h-16 mx-auto text-indigo-600 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <svg className="w-16 h-16 mx-auto text-aura-primary mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
                 <p className="text-gray-700 text-xl">Enviando tu encuesta...</p>
@@ -305,7 +308,7 @@ const SurveyForm: React.FC<SurveyFormProps> = ({ survey }) => {
     }
 
     // Usar color índigo por defecto para la pantalla de contexto
-    const contextColor = 'indigo'; 
+    const contextColor = 'aura-primary'; 
     if (showContext) {
         console.log("Render: Pantalla de contexto");
         return (
@@ -326,7 +329,7 @@ const SurveyForm: React.FC<SurveyFormProps> = ({ survey }) => {
                 </p>
                 <button
                     onClick={handleContextClick}
-                    className={`w-full ${bgButtonClasses[contextColor]} text-white py-3 px-6 rounded-lg ${hoverBgClasses[contextColor]} transition-colors transform hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 font-medium text-lg`}
+                    className={`w-full ${bgDarkColorClasses[contextColor]} text-aura-text-light py-3 px-6 rounded-lg ${hoverBgDarkColorClasses[contextColor]} transition-colors transform hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-aura-primary/50 focus:ring-offset-2 font-medium text-lg`}
                 >
                     Comenzar Encuesta
                 </button>
@@ -338,7 +341,7 @@ const SurveyForm: React.FC<SurveyFormProps> = ({ survey }) => {
         console.log("Render: Cargando primera sección...");
         return (
             <div className="max-w-2xl mx-auto p-8 bg-white rounded-xl shadow-lg text-center transform transition-all duration-500 animate-pulse">
-                 <svg className="w-16 h-16 mx-auto text-indigo-600 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                 <svg className="w-16 h-16 mx-auto text-aura-primary mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
                 <p className="text-gray-700 text-xl">¡Genial! Cargando la primera sección...</p>
@@ -360,7 +363,7 @@ const SurveyForm: React.FC<SurveyFormProps> = ({ survey }) => {
 
             <div className={`space-y-6 ${animation}`}>
                 {survey.blocks.map((block, index) => {
-                    const blockColorName = blockColorMap[block.blockId] || 'indigo';
+                    const blockColorName = blockColorMap[block.blockId] || 'aura-primary';
                     const isCurrent = currentStep === index + 1;
 
                     return (
@@ -369,10 +372,10 @@ const SurveyForm: React.FC<SurveyFormProps> = ({ survey }) => {
                             className={`step ${isCurrent ? 'block' : 'hidden'} ${borderColorClasses[blockColorName]} bg-white p-4 md:p-6 rounded-lg shadow-md transform transition-all duration-300`}
                         >
                             <div className="md:hidden text-center mb-4 pb-3 border-b border-gray-100">
-                                <span className={`inline-flex items-center justify-center w-8 h-8 rounded-full ${bgColorClasses[blockColorName]} ${textColorClasses[blockColorName]} border-2 ${borderColorClasses[blockColorName]} mb-2`}>
+                                <span className={`inline-flex items-center justify-center w-8 h-8 rounded-full ${bgColorClasses[blockColorName]} ${textColorClasses[blockColorName]} border-2 ${borderColorClasses[blockColorName].replace('border-t-4 ','')} mb-2`}>
                                     <span>{index + 1}</span>
                                 </span>
-                                <h3 className="text-lg font-semibold text-gray-900">{block.title}</h3>
+                                <h3 className="text-lg font-semibold text-aura-text-dark">{block.title}</h3>
                             </div>
                             
                             <div className="hidden md:flex items-start mb-6">
@@ -382,7 +385,7 @@ const SurveyForm: React.FC<SurveyFormProps> = ({ survey }) => {
                                     })}
                                 </div>
                                 <div>
-                                    <legend className="text-xl font-semibold text-gray-900">{block.title}</legend>
+                                    <legend className="text-xl font-semibold text-aura-text-dark">{block.title}</legend>
                                     <p className="text-sm text-gray-500 mt-1">{block.description}</p>
                                 </div>
                             </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,22 +3,24 @@ export default {
   content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
   darkMode: 'class',
   safelist: [
-    // Colores para bordes
-    'border-indigo-600', 'border-purple-600', 'border-sky-600', 
-    'border-teal-600', 'border-rose-600', 'border-emerald-600',
-    // Colores para fondos
-    'bg-indigo-600', 'bg-indigo-100', 'text-indigo-600',
-    'bg-purple-600', 'bg-purple-100', 'text-purple-600',
-    'bg-sky-600', 'bg-sky-100', 'text-sky-600',
-    'bg-teal-600', 'bg-teal-100', 'text-teal-600',
-    'bg-rose-600', 'bg-rose-100', 'text-rose-600',
-    'bg-emerald-600', 'bg-emerald-100', 'text-emerald-600',
-    // Hover states
-    'hover:bg-indigo-700', 'hover:bg-purple-700', 'hover:bg-sky-700',
-    'hover:bg-teal-700', 'hover:bg-rose-700', 'hover:bg-emerald-700',
-    // Text colors
-    'text-indigo-900', 'text-purple-900', 'text-sky-900',
-    'text-teal-900', 'text-rose-900', 'text-emerald-900',
+    // Colores AURA para bordes (con border-t-4 implícito)
+    'border-aura-primary', 'border-aura-secondary', 'border-aura-accent',
+    'border-aura-rose', 'border-aura-orange', 'border-aura-green',
+    // Colores AURA para fondos claros (con opacidad)
+    'bg-aura-primary/10', 'bg-aura-secondary/10', 'bg-aura-accent/10',
+    'bg-aura-rose/10', 'bg-aura-orange/10', 'bg-aura-green/10',
+    // Colores AURA para fondos oscuros/sólidos
+    'bg-aura-primary', 'bg-aura-secondary', 'bg-aura-accent',
+    'bg-aura-rose', 'bg-aura-orange', 'bg-aura-green',
+    // Colores AURA para texto
+    'text-aura-primary', 'text-aura-secondary', 'text-aura-accent',
+    'text-aura-rose', 'text-aura-orange', 'text-aura-green',
+    'text-aura-text-light', 'text-aura-text-dark',
+    // Hover states para fondos oscuros
+    'hover:bg-aura-primary/90', 'hover:bg-aura-secondary/90', 'hover:bg-aura-accent/90',
+    'hover:bg-aura-rose/90', 'hover:bg-aura-orange/90', 'hover:bg-aura-green/90',
+    // Clases específicas de focus
+    'focus:ring-aura-primary/50',
   ],
   theme: {
     extend: {
@@ -26,6 +28,15 @@ export default {
         primary: '#301E47',
         accent: '#FAC657',
         background: '#FDFDF7',
+        'aura-primary': '#AA49CC',      // Morado principal
+        'aura-secondary': '#7CE0C8',    // Turquesa
+        'aura-accent': '#FFC33F',       // Amarillo cálido
+        'aura-rose': '#CB629A',          // Rosa/Morado (del gradiente)
+        'aura-orange': '#ED9263',       // Naranja (del gradiente)
+        'aura-green': '#97DDAB',        // Verde Claro (highlight)
+        'aura-text-light': '#FDFDF7',
+        'aura-text-muted': '#E2E2E0',
+        'aura-text-dark': '#2A1B3D',
       },
       fontFamily: {
         sans: ['Inter var', 'system-ui', 'sans-serif'],


### PR DESCRIPTION
Se ha actualizado la interfaz de la encuesta para utilizar la paleta de colores oficial de AURA:

- Configuración: Añadida paleta de colores AURA en tailwind.config.js con variables específicas
- Mapeo: Actualizado blockColorMap en SurveyForm.tsx para usar los colores AURA:
  * perfilProfesional -> aura-primary (Morado)
  * gestionClientesDolor -> aura-rose (Rosa)
  * creacionEntregaPlanes -> aura-secondary (Turquesa)
  * usoPlataformasDigitales -> aura-green (Verde)
  * diferenciacionComunicacion -> aura-orange (Naranja)
  * interesAura -> aura-accent (Amarillo)
- Componentes: Actualizados SurveyForm.tsx y ProgressBar.tsx para usar las nuevas clases
- Optimización: Añadido safelist en tailwind.config.js para preservar clases dinámicas